### PR TITLE
Simplified phonenumber validation regex:

### DIFF
--- a/FSBeheer/FSBeheer/ViewModel/CreateEditContactViewModel.cs
+++ b/FSBeheer/FSBeheer/ViewModel/CreateEditContactViewModel.cs
@@ -122,9 +122,9 @@ namespace FSBeheer.ViewModel
                 return false;
             }
 
-            if (!Regex.Match(Contact.PhoneNumber.Trim(), @"^((((\+|(00))(31))6?)|(06))?[0-9]{8}$").Success)
+            if (!Regex.Match(Contact.PhoneNumber.Trim(), @"^\+{1}[0-9]{11}$").Success)
             {
-                MessageBox.Show("Het ingevoerde telefoonnummer is incorrect.");
+                MessageBox.Show("Het ingevoerde telefoonnummer is incorrect.\nEen valide telefoonnummer is bijvoorbeeld +31601234567.");
                 return false;
             }
 

--- a/FSBeheer/FSBeheer/ViewModel/CreateEditInspectorViewModel.cs
+++ b/FSBeheer/FSBeheer/ViewModel/CreateEditInspectorViewModel.cs
@@ -180,9 +180,9 @@ namespace FSBeheer.ViewModel
                 return false;
             }
 
-            if (!Regex.Match(Inspector.PhoneNumber.Trim(), @"^((((\+|(00))(31))6?)|(06))?[0-9]{8}$").Success)
+            if (!Regex.Match(Inspector.PhoneNumber.Trim(), @"^\+{1}[0-9]{11}$").Success)
             {
-                MessageBox.Show("Het ingevoerde telefoonnummer is incorrect.");
+                MessageBox.Show("Het ingevoerde telefoonnummer is incorrect.\nEen valide telefoonnummer is bijvoorbeeld +31601234567.");
                 return false;
             }
 


### PR DESCRIPTION
 now requires a total of 11 digits and must start with a + symbol.

Simplification of the phonenumber validation regex, as per "Telefoonnummer hoeft niet per se met 316 te beginnen, kan ook 318 zijn bijvoorbeeld (snel opgelost)
Telefoonnummer hoeft geen mobiel nummer te zijn" in Acceptatietest notities.